### PR TITLE
Add mounted checks before async setState calls

### DIFF
--- a/lib/page/Home.dart
+++ b/lib/page/Home.dart
@@ -66,6 +66,7 @@ class homePage extends State<HomePage> {
       size: AdSize.mediumRectangle,
       listener: BannerAdListener(
         onAdLoaded: (_) {
+          if (!mounted) return;
           setState(() {
             _isBannerAdReady = true;
           });
@@ -279,6 +280,7 @@ class homePage extends State<HomePage> {
     });
     dailyPrayer=fetchPrayerDaily();
     initializePreference().whenComplete((){
+      if (!mounted) return;
       setState(() {
         _currentAddress=this.preferences?.getString("_prefCurrentAddress");
         print(preferences?.getString("name"));

--- a/lib/page/daily_prayer.dart
+++ b/lib/page/daily_prayer.dart
@@ -25,6 +25,7 @@ class _DailyPrayer extends State<DailyPrayerPage> {
   void dailyPrayertoList() async{
     var temp=await fetchPrayerDailyAll();
     print(temp.length);
+    if (!mounted) return;
     setState(() {
       items=temp;
     });
@@ -38,6 +39,7 @@ class _DailyPrayer extends State<DailyPrayerPage> {
       size: AdSize.mediumRectangle,
       listener: BannerAdListener(
         onAdLoaded: (_) {
+          if (!mounted) return;
           setState(() {
             _isBannerAdReady = true;
           });

--- a/lib/page/list_surah.dart
+++ b/lib/page/list_surah.dart
@@ -35,6 +35,7 @@ class _ListSurahPage extends State<ListSurahPage> {
   void allSurahToList() async{
     var temp=await readJsonAllSurah();
     print(temp.length);
+    if (!mounted) return;
     setState(() {
       items=temp;
     });
@@ -49,6 +50,7 @@ class _ListSurahPage extends State<ListSurahPage> {
       size: AdSize.mediumRectangle,
       listener: BannerAdListener(
         onAdLoaded: (_) {
+          if (!mounted) return;
           setState(() {
             _isBannerAdReady = true;
           });
@@ -94,6 +96,7 @@ class _ListSurahPage extends State<ListSurahPage> {
     _bookmarkSurah=null;
     AnalyticsService.observer.analytics.setCurrentScreen(screenName: "list_surah");
     initializePreference().whenComplete((){
+      if (!mounted) return;
       setState(() {
         refreshbookmark();
       });

--- a/lib/page/prayerTime.dart
+++ b/lib/page/prayerTime.dart
@@ -72,6 +72,7 @@ class _PrayerTimeState extends State<PrayerTime> {
     super.initState();
 
     initializePreference().whenComplete((){
+      if (!mounted) return;
       setState(() {
         _getPrayTime(preferences?.getDouble("_preflatitude"),preferences?.getDouble("_preflongitude"));
         print(_prayerTimeModel.datePrayer);

--- a/lib/page/read_alquran.dart
+++ b/lib/page/read_alquran.dart
@@ -91,6 +91,7 @@ class _ReadQuranPage extends State<ReadQuranPage> {
       size: AdSize.mediumRectangle,
       listener: BannerAdListener(
         onAdLoaded: (_) {
+          if (!mounted) return;
           setState(() {
             _isBannerAdReady = true;
           });
@@ -115,6 +116,7 @@ class _ReadQuranPage extends State<ReadQuranPage> {
     super.initState();
     AnalyticsService.observer.analytics.setCurrentScreen(screenName: "read_quran");
     initializePreference().whenComplete((){
+      if (!mounted) return;
       setState(() {
         _bookmarkAyat=preferences?.getInt("_bookmarkAyat");
         _bookmarkSurah=preferences?.getInt("_bookmarkSurah");
@@ -122,6 +124,7 @@ class _ReadQuranPage extends State<ReadQuranPage> {
       });
     });
     allSurahToList().then((value){
+      if (!mounted) return;
       setState(() {
         _isLoading=false;
         items=value;

--- a/lib/page/setting.dart
+++ b/lib/page/setting.dart
@@ -68,6 +68,7 @@ class _SettingPage extends State<SettingPage> {
       size: AdSize.mediumRectangle,
       listener: BannerAdListener(
         onAdLoaded: (_) {
+          if (!mounted) return;
           setState(() {
             _isBannerAdReady = true;
           });
@@ -108,6 +109,7 @@ class _SettingPage extends State<SettingPage> {
     if (!hasPermission) return;
     await Geolocator.getCurrentPosition(desiredAccuracy: LocationAccuracy.high)
         .then((Position position) {
+      if (!mounted) return;
       setState(() => _currentPosition = position);
       print(position);
       _getAddressFromLatLng(_currentPosition!);
@@ -121,6 +123,7 @@ class _SettingPage extends State<SettingPage> {
     await placemarkFromCoordinates(
             _currentPosition!.latitude, _currentPosition!.longitude)
         .then((List<Placemark> placemarks) {
+      if (!mounted) return;
       Placemark place = placemarks[0];
 
       final myCoordinates = Coordinates(
@@ -347,6 +350,7 @@ class _SettingPage extends State<SettingPage> {
       }
     });
     initializePreference().whenComplete(() {
+      if (!mounted) return;
       setState(() {
         isSwitchedShubuh =
             this.preferences?.getBool('_isSwitchedShubuh') ?? false;
@@ -411,6 +415,7 @@ class _SettingPage extends State<SettingPage> {
                   showLoaderDialog(context);
                   requestLocation().whenComplete(() {
                     print("okksss");
+                    if (!mounted) return;
                     setState(() {
                       _currentAddress =
                           this.preferences?.getString("_prefCurrentAddress");
@@ -438,6 +443,7 @@ class _SettingPage extends State<SettingPage> {
                       value: isNotifPermision,
                       onChanged: (value){
                         _permissionNotif(value).then((tt){
+                          if (!mounted) return;
                           if(tt.item1){
                             setState(() {
                               print('ttttt ${tt.item1}');
@@ -462,6 +468,7 @@ class _SettingPage extends State<SettingPage> {
                       value: isSwitchedShubuh,
                       onChanged: (value) {
                         setAdzanShubuh(value).then((Tuple2 rr) {
+                          if (!mounted) return;
                           if (rr.item1) {
                             setState(() {
                               NotifTest();
@@ -489,6 +496,7 @@ class _SettingPage extends State<SettingPage> {
                       value: isSwitchedzuhur,
                       onChanged: (value) {
                         setAdzanZuhur(value).then((Tuple2 rr) {
+                          if (!mounted) return;
                           if (rr.item1) {
                             setState(() {
                               isSwitchedzuhur = value;
@@ -514,6 +522,7 @@ class _SettingPage extends State<SettingPage> {
                       value: isSwitchedashar,
                       onChanged: (value) {
                         setAdzanAshar(value).then((Tuple2 rr) {
+                          if (!mounted) return;
                           if (rr.item1){
                             setState(() {
                               isSwitchedashar = value;
@@ -542,6 +551,7 @@ class _SettingPage extends State<SettingPage> {
                       onChanged: (value) {
 
                         setAdzanMakrib(value).then((Tuple2 rr) {
+                          if (!mounted) return;
                           if(rr.item1){
                             setState(() {
                               isSwitchedmakrib = value;
@@ -570,6 +580,7 @@ class _SettingPage extends State<SettingPage> {
                       value: isSwitchedisya,
                       onChanged: (value) {
                         setAdzanIsya(value).then((Tuple2 rr) {
+                          if (!mounted) return;
                           if(rr.item1){
                             setState(() {
                               isSwitchedisya = value;

--- a/lib/page/test.dart
+++ b/lib/page/test.dart
@@ -55,6 +55,7 @@ class _LocationPageState extends State<LocationPage> {
     if (!hasPermission) return;
     await Geolocator.getCurrentPosition(desiredAccuracy: LocationAccuracy.high)
         .then((Position position) {
+      if (!mounted) return;
       setState(() => _currentPosition = position);
       _getAddressFromLatLng(_currentPosition!);
     }).catchError((e) {
@@ -66,6 +67,7 @@ class _LocationPageState extends State<LocationPage> {
     await placemarkFromCoordinates(
         _currentPosition!.latitude, _currentPosition!.longitude)
         .then((List<Placemark> placemarks) {
+      if (!mounted) return;
       Placemark place = placemarks[0];
       setState(() {
         _currentAddress =


### PR DESCRIPTION
## Summary
- guard BannerAd callbacks, preference initialization, and other async completions in Home, PrayerTime, List Surah, Read Alquran, Setting, Daily Prayer, and test pages
- ensure async data loaders and preference updates verify the widget is still mounted before calling setState

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68de3d55509c8326a2994b354ac5a855